### PR TITLE
Update SONATYPE publishing repository url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,5 +45,5 @@ jobs:
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_SECRET_KEYS_ENC: ${{ secrets.GPG_SECRET_KEYS_ENC }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_CENTRAL_USERNAME: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+          SONATYPE_CENTRAL_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ version = '1.0.0-SNAPSHOT'
 repositories {
     mavenCentral()
     maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
+        url "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots"
     }
     mavenLocal()
 }
@@ -234,8 +234,8 @@ publishing {
 
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
                 username System.getenv('SONATYPE_CENTRAL_USERNAME')

--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ sourceSets {
 }
 
 nexusStaging {
-    username = System.getenv('SONATYPE_USERNAME')
-    password = System.getenv('SONATYPE_PASSWORD')
+    username = System.getenv('SONATYPE_CENTRAL_USERNAME')
+    password = System.getenv('SONATYPE_CENTRAL_PASSWORD')
 }
 
 
@@ -238,8 +238,8 @@ publishing {
             def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
-                username System.getenv('SONATYPE_USERNAME')
-                password System.getenv('SONATYPE_PASSWORD')
+                username System.getenv('SONATYPE_CENTRAL_USERNAME')
+                password System.getenv('SONATYPE_CENTRAL_PASSWORD')
             }
         }
     }

--- a/ci/upload_to_maven.sh
+++ b/ci/upload_to_maven.sh
@@ -8,7 +8,7 @@ echo "$GPG_SECRET_KEYS_ENC" | base64 --decode > "$GPG_KEY_LOCATION"
 export PROJECT_VERSION="$(./gradlew properties -q | grep "^version: " | awk '{print $2}')"
 echo "\$PROJECT_VERSION: $PROJECT_VERSION" >&2
 # Upload only snapshots to Sonatype OSS so it can make its way to Maven Central
-# https://oss.sonatype.org/content/repositories/snapshots/io/tiledb/tiledb-cloud-java/
+# https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/io/tiledb/tiledb-cloud-java/
 ./gradlew publishMavenJavaPublicationToMavenRepository
 
 # Only non-snapshot can be pushed as Maven releases


### PR DESCRIPTION
This updates the SONATYPE url for the new staging API that serves as a shim. https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#getting-started-for-maven-api-like-plugins . We also update to new ENVs for username/password for maven upload. I opted for new secrets in the repo, so I wouldn't override the old secrets while setting this up. The old secrets will be safe to delete after merging.